### PR TITLE
Make panel dockable 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+.env
+__pycache__/

--- a/forms/ui_filter.ui
+++ b/forms/ui_filter.ui
@@ -29,6 +29,9 @@
         <pointsize>11</pointsize>
        </font>
       </property>
+      <property name="filters">
+       <set>QgsMapLayerProxyModel::AnnotationLayer|QgsMapLayerProxyModel::HasGeometry|QgsMapLayerProxyModel::LineLayer|QgsMapLayerProxyModel::NoGeometry|QgsMapLayerProxyModel::PluginLayer|QgsMapLayerProxyModel::PointCloudLayer|QgsMapLayerProxyModel::PointLayer|QgsMapLayerProxyModel::PolygonLayer|QgsMapLayerProxyModel::VectorLayer|QgsMapLayerProxyModel::VectorTileLayer</set>
+      </property>
      </widget>
     </item>
     <item row="1" column="0" colspan="2">

--- a/forms/ui_filter.ui
+++ b/forms/ui_filter.ui
@@ -29,9 +29,6 @@
         <pointsize>11</pointsize>
        </font>
       </property>
-      <property name="filters">
-       <set>QgsMapLayerProxyModel::AnnotationLayer|QgsMapLayerProxyModel::HasGeometry|QgsMapLayerProxyModel::LineLayer|QgsMapLayerProxyModel::NoGeometry|QgsMapLayerProxyModel::PluginLayer|QgsMapLayerProxyModel::PointCloudLayer|QgsMapLayerProxyModel::PointLayer|QgsMapLayerProxyModel::PolygonLayer|QgsMapLayerProxyModel::VectorLayer|QgsMapLayerProxyModel::VectorTileLayer</set>
-      </property>
      </widget>
     </item>
     <item row="1" column="0" colspan="2">

--- a/forms/ui_filter.ui
+++ b/forms/ui_filter.ui
@@ -1,230 +1,168 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>DockWidget</class>
+ <widget class="QDockWidget" name="DockWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>287</width>
-    <height>488</height>
+    <height>504</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Get'em filtered!</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <property name="modal">
-   <bool>false</bool>
-  </property>
-  <widget class="QgsMapLayerComboBox" name="cob_layer">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>20</y>
-     <width>249</width>
-     <height>24</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-  </widget>
-  <widget class="QgsFieldComboBox" name="cob_field">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>50</y>
-     <width>249</width>
-     <height>24</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="chb_go">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>80</y>
-     <width>111</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>Do Filtering</string>
-   </property>
-  </widget>
-  <widget class="QListWidget" name="list_values">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>106</y>
-     <width>249</width>
-     <height>299</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="focusPolicy">
-    <enum>Qt::TabFocus</enum>
-   </property>
-   <property name="selectionMode">
-    <enum>QAbstractItemView::MultiSelection</enum>
-   </property>
-  </widget>
-  <widget class="QCheckBox" name="chb_zoom">
-   <property name="geometry">
-    <rect>
-     <x>150</x>
-     <y>80</y>
-     <width>121</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>Zoom to items</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="but_select_all">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>411</y>
-     <width>91</width>
-     <height>30</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>Select all</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="but_deselect_all">
-   <property name="geometry">
-    <rect>
-     <x>150</x>
-     <y>411</y>
-     <width>101</width>
-     <height>30</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>De-select all</string>
-   </property>
-  </widget>
-  <widget class="QRadioButton" name="rdo_single">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>460</y>
-     <width>91</width>
-     <height>17</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>1 element</string>
-   </property>
-  </widget>
-  <widget class="QRadioButton" name="rdo_multi">
-   <property name="geometry">
-    <rect>
-     <x>140</x>
-     <y>460</y>
-     <width>121</width>
-     <height>17</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <family>Roboto</family>
-     <pointsize>11</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>Many elements</string>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0" colspan="2">
+     <widget class="QgsMapLayerComboBox" name="cob_layer">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <widget class="QgsFieldComboBox" name="cob_field">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QCheckBox" name="chb_go">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Do Filtering</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QCheckBox" name="chb_zoom">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Zoom to items</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0" colspan="2">
+     <widget class="QListWidget" name="list_values">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="focusPolicy">
+       <enum>Qt::TabFocus</enum>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::MultiSelection</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QPushButton" name="but_select_all">
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Select all</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QPushButton" name="but_deselect_all">
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>De-select all</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="0">
+     <widget class="QRadioButton" name="rdo_single">
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>1 element</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QRadioButton" name="rdo_multi">
+      <property name="font">
+       <font>
+        <family>Roboto</family>
+        <pointsize>11</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Many elements</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <customwidgets>

--- a/get_them_filtered_dialog.py
+++ b/get_them_filtered_dialog.py
@@ -27,10 +27,10 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'forms/ui_filter.ui'))
 
 
-class GetThemFilteredDialog(QtWidgets.QDialog, FORM_CLASS):
+class GetThemFilteredDialog(QtWidgets.QDockWidget, FORM_CLASS):
 
     def __init__(self, iface, parent=None):
-        QtWidgets.QDialog.__init__(self, None, QtCore.Qt.WindowStaysOnTopHint)
+        QtWidgets.QDockWidget.__init__(self, None, QtCore.Qt.WindowStaysOnTopHint)
 
         self.setupUi(self)
         self.iface = iface

--- a/get_them_filtered_dialog.py
+++ b/get_them_filtered_dialog.py
@@ -14,6 +14,8 @@ import qgis
 from qgis.PyQt import QtWidgets, uic, QtGui, QtCore, QtWidgets
 from qgis.PyQt.QtWidgets import *
 from qgis.core import QgsProject
+from qgis.PyQt.QtCore import pyqtSignal
+
 
 sys.modules["qgsfieldcombobox"] = qgis.gui
 sys.modules["qgsmaplayercombobox"] = qgis.gui
@@ -28,6 +30,8 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(
 
 
 class GetThemFilteredDialog(QtWidgets.QDockWidget, FORM_CLASS):
+
+    closingPlugin = pyqtSignal()
 
     def __init__(self, iface, parent=None):
         QtWidgets.QDockWidget.__init__(self, None, QtCore.Qt.WindowStaysOnTopHint)
@@ -138,3 +142,7 @@ class GetThemFilteredDialog(QtWidgets.QDockWidget, FORM_CLASS):
 
     def select_all(self):
         self.list_values.selectAll()
+
+    def closeEvent(self, event):
+        self.closingPlugin.emit()
+        event.accept()

--- a/getthemfiltered.py
+++ b/getthemfiltered.py
@@ -75,10 +75,6 @@ class getThemFiltered:
         self.pluginIsActive = False
 
     def run(self, checked: bool):
-        # The triggered signal includes a bool 
-        # that indicates whether the button was checked or unchecked
-        self.dockwidget.setVisible(checked)
-
         if not self.pluginIsActive:
             self.pluginIsActive = True
             if self.dockwidget is None:
@@ -91,3 +87,7 @@ class getThemFiltered:
                 area=Qt.LeftDockWidgetArea,
                 dockwidget=self.dockwidget,
             )
+            
+        # The triggered signal includes a bool 
+        # that indicates whether the button was checked or unchecked
+        self.dockwidget.setVisible(checked)

--- a/getthemfiltered.py
+++ b/getthemfiltered.py
@@ -12,7 +12,7 @@
 
 from __future__ import absolute_import
 import os.path
-from qgis.PyQt.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
+from qgis.PyQt.QtCore import Qt, QSettings, QTranslator, qVersion, QCoreApplication
 from qgis.PyQt.QtWidgets import QAction
 from qgis.PyQt.QtGui import QIcon
 from .get_them_filtered_dialog import GetThemFilteredDialog
@@ -25,12 +25,14 @@ class getThemFiltered(object):
         self.iface = iface
         self.plugin_dir = os.path.dirname(__file__)
         self.icon_path = os.path.join(self.plugin_dir, 'icon.svg')
-        self.dlg = GetThemFilteredDialog(self.iface)
         self.actions = []
         self.menu = self.tr(u'&GetThemFiltered')
 
         self.toolbar = self.iface.addToolBar(u'GetThemFiltered')
         self.toolbar.setObjectName(u'GetThemFiltered')
+        
+        self.pluginIsActive = False
+        self.dockwidget = None
 
     def tr(self, message):
         """
@@ -60,6 +62,27 @@ class getThemFiltered(object):
             self.iface.removePluginMenu(self.tr(u'&GetThemFiltered'), action)
             self.iface.removeToolBarIcon(action)
 
+    def onClosePlugin(self):
+        """Cleanup necessary items here when plugin dockwidget is closed"""
+
+        # disconnects
+        self.dockwidget.closingPlugin.disconnect(self.onClosePlugin)
+
+        self.pluginIsActive = False
+
     def run(self):
-        self.dlg.show()
-        self.dlg.exec_()
+        if not self.pluginIsActive:
+            self.pluginIsActive = True
+            if self.dockwidget is None:
+                self.dockwidget = GetThemFilteredDialog(self.iface)
+
+            self.dockwidget.closingPlugin.connect(self.onClosePlugin)
+
+            self.iface.addDockWidget(
+                area = Qt.LeftDockWidgetArea,
+                dockwidget = self.dockwidget,
+            )
+
+
+            self.dockwidget.show()
+            # self.dlg.exec_()

--- a/getthemfiltered.py
+++ b/getthemfiltered.py
@@ -50,7 +50,6 @@ class getThemFiltered:
         icon = QIcon(self.icon_path)
         self.panelAction = QAction(icon, self.tr(u'GetThemFiltered'), self.iface.mainWindow())
         self.panelAction.triggered.connect(self.run)
-        self.panelAction.triggered.connect(self.openWidget)
         self.panelAction.setCheckable(True)
         self.panelAction.setEnabled(True)
 
@@ -75,10 +74,11 @@ class getThemFiltered:
 
         self.pluginIsActive = False
 
-    def openWidget(self, show: bool) -> None:
-        self.dockwidget.setVisible(show)
+    def run(self, checked: bool):
+        # The triggered signal includes a bool 
+        # that indicates whether the button was checked or unchecked
+        self.dockwidget.setVisible(checked)
 
-    def run(self):
         if not self.pluginIsActive:
             self.pluginIsActive = True
             if self.dockwidget is None:

--- a/getthemfiltered.py
+++ b/getthemfiltered.py
@@ -18,7 +18,7 @@ from qgis.PyQt.QtGui import QIcon
 from .get_them_filtered_dialog import GetThemFilteredDialog
 
 
-class getThemFiltered(object):
+class getThemFiltered:
     """QGIS Plugin Implementation."""
 
     def __init__(self, iface):

--- a/getthemfiltered.py
+++ b/getthemfiltered.py
@@ -48,19 +48,24 @@ class getThemFiltered:
 
         """Add a toolbar icon to the toolbar."""
         icon = QIcon(self.icon_path)
-        action = QAction(icon, self.tr(u'GetThemFiltered'), self.iface.mainWindow())
-        action.triggered.connect(self.run)
-        action.setEnabled(True)
+        self.panelAction = QAction(icon, self.tr(u'GetThemFiltered'), self.iface.mainWindow())
+        self.panelAction.triggered.connect(self.run)
+        self.panelAction.triggered.connect(self.openWidget)
+        self.panelAction.setCheckable(True)
+        self.panelAction.setEnabled(True)
 
-        self.toolbar.addAction(action)
-        self.iface.addPluginToMenu(self.menu, action)
-        self.actions.append(action)
+        self.toolbar.addAction(self.panelAction)
+        self.iface.addPluginToMenu(self.menu, self.panelAction)
+        self.actions.append(self.panelAction)
 
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
             self.iface.removePluginMenu(self.tr(u'&GetThemFiltered'), action)
             self.iface.removeToolBarIcon(action)
+
+    def widgetVisibilityChanged(self, visible: bool) -> None:
+        self.panelAction.setChecked(visible)
 
     def onClosePlugin(self):
         """Cleanup necessary items here when plugin dockwidget is closed"""
@@ -70,19 +75,19 @@ class getThemFiltered:
 
         self.pluginIsActive = False
 
+    def openWidget(self, show: bool) -> None:
+        self.dockwidget.setVisible(show)
+
     def run(self):
         if not self.pluginIsActive:
             self.pluginIsActive = True
             if self.dockwidget is None:
                 self.dockwidget = GetThemFilteredDialog(self.iface)
+            self.dockwidget.visibilityChanged.connect(self.widgetVisibilityChanged)
 
             self.dockwidget.closingPlugin.connect(self.onClosePlugin)
 
             self.iface.addDockWidget(
-                area = Qt.LeftDockWidgetArea,
-                dockwidget = self.dockwidget,
+                area=Qt.LeftDockWidgetArea,
+                dockwidget=self.dockwidget,
             )
-
-
-            self.dockwidget.show()
-            # self.dlg.exec_()

--- a/metadata.txt
+++ b/metadata.txt
@@ -4,8 +4,8 @@ qgisMinimumVersion=3.4
 qgisMaximumVersion=3.99
 description=Quickly filter a given layer by the unique values from a field.
 about=Recursively filter a given layer by its values.
-version=0.1.3
-author=Pedro Camargo
+version=0.2.0
+author=Pedro Camargo, Evan Derickson
 email=c@margo.co
 hasProcessingProvider=no
 # For QGIS WPS
@@ -17,6 +17,8 @@ server=True
 
 # Uncomment the following line and add your changelog:
 # changelog=
+  Version 0.2.0
+  * Make widget dockable
   Version 0.1.2
   * First version
 


### PR DESCRIPTION
Changes the widget from a dialog to a dockwidget, making this plugin work more like other QGIS plugins.

TODO:
- [x] Make the menu icon a toggle, toggling the widget open or closed, and showing in a pushed state while the widget is open 

Closes #10 